### PR TITLE
APP-1374: Kotlin ergonomics-fixes

### DIFF
--- a/_templates/generator/eventDocumentation/event.md.t
+++ b/_templates/generator/eventDocumentation/event.md.t
@@ -24,7 +24,7 @@ hAnalyticsEvent.<%= event.accessor %>(<%= (event.inputs ?? []).map((input) => `$
 ## Kotlin
 
 ```kotlin
-hAnalyticsEvent.Companion.<%= event.accessor %>(<%= (event.inputs ?? []).map((input) => `${input.argument}: ${kotlinTypeMap(input.type)}`).join(",") %>)
+hAnalytics.<%= event.accessor %>(<%= (event.inputs ?? []).map((input) => `${input.argument}: ${kotlinTypeMap(input.type)}`).join(",") %>)
 ```
 
 ## Integration status

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,15 @@ plugins {
 }
 
 java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
     withSourcesJar()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_11.toString()
+    }
 }
 
 sourceSets {

--- a/commons/typeMaps.js
+++ b/commons/typeMaps.js
@@ -32,7 +32,7 @@ const getKotlinType = (type) => {
         "Boolean": "Boolean",
         "Double": "Double",
         "Optional": (s) => `${s}?`,
-        "Array": (s) => `Array<${s}>`,
+        "Array": (s) => `List<${s}>`,
         "Dictionary": (s) => `Map<${s}>`
     }
 

--- a/commons/typeMaps.test.js
+++ b/commons/typeMaps.test.js
@@ -8,8 +8,8 @@ test('swiftTypeMap', () => {
 });
 
 test('kotlinTypeMap', () => {
-    expect(typeMaps.kotlinTypeMap("Array<String>")).toEqual("Array<String>")
-    expect(typeMaps.kotlinTypeMap("Array<Boolean>")).toEqual("Array<Boolean>")
-    expect(typeMaps.kotlinTypeMap("Array<Dictionary<String, String>>")).toEqual("Array<Map<String, String>>")
+    expect(typeMaps.kotlinTypeMap("Array<String>")).toEqual("List<String>")
+    expect(typeMaps.kotlinTypeMap("Array<Boolean>")).toEqual("List<Boolean>")
+    expect(typeMaps.kotlinTypeMap("Array<Dictionary<String, String>>")).toEqual("List<Map<String, String>>")
     expect(typeMaps.kotlinTypeMap("Optional<String>")).toEqual("String?")
 });

--- a/events/embark/embarkTrack.yml
+++ b/events/embark/embarkTrack.yml
@@ -9,5 +9,5 @@ inputs:
     type: String
     argument: eventName
   - name: store
-    type: Dictionary<String, Any>
+    type: Dictionary<String, Any?>
     argument: store

--- a/kotlin/src/main/kotlin/com/hedvig/hanalytics/HAnalytics.kt
+++ b/kotlin/src/main/kotlin/com/hedvig/hanalytics/HAnalytics.kt
@@ -171,7 +171,7 @@ abstract class HAnalytics {
     /**
      * When embark sends a tracking event
      */
-    fun embarkTrack(storyName: String, eventName: String, store: Map<String, Any>) {
+    fun embarkTrack(storyName: String, eventName: String, store: Map<String, Any?>) {
         send(
             HAnalyticsEvent(
                 name = "embark_track",
@@ -186,7 +186,7 @@ abstract class HAnalytics {
     /**
      * When embark does a varianted offer redirect
      */
-    fun embarkVariantedOfferRedirect(allIds: Array<String>, selectedIds: Array<String>) {
+    fun embarkVariantedOfferRedirect(allIds: List<String>, selectedIds: List<String>) {
         send(
             HAnalyticsEvent(
                 name = "embark_varianted_offer_redirect",
@@ -238,7 +238,7 @@ abstract class HAnalytics {
     /**
      * Experiments where loaded from server
      */
-    fun experimentsLoaded(experiments: Array<String>) {
+    fun experimentsLoaded(experiments: List<String>) {
         send(
             HAnalyticsEvent(
                 name = "experiments_loaded",
@@ -312,7 +312,7 @@ abstract class HAnalytics {
     /**
      * When quotes are signed in the offer screen
      */
-    fun quotesSigned(quoteIds: Array<String>) {
+    fun quotesSigned(quoteIds: List<String>) {
         send(
             HAnalyticsEvent(
                 name = "quotes_signed",
@@ -486,7 +486,7 @@ query QuotesSigned(${"\$"}quote_ids: [ID!]!) {
     /**
      * When Offer screen is shown
      */
-    fun screenViewOffer(offerIds: Array<String>) {
+    fun screenViewOffer(offerIds: List<String>) {
         send(
             HAnalyticsEvent(
                 name = "screen_view_offer",

--- a/swift/hAnalyticsEvent.swift
+++ b/swift/hAnalyticsEvent.swift
@@ -168,7 +168,7 @@ extension hAnalyticsEvent {
   }
 
   /// When embark sends a tracking event
-  public static func embarkTrack(storyName: String, eventName: String, store: [String: Any])
+  public static func embarkTrack(storyName: String, eventName: String, store: [String: Any?])
     -> hAnalyticsParcel
   {
     return hAnalyticsParcel {


### PR DESCRIPTION
- Set sourceCompatibility to 11
- Generate `Dictionary<String, Any?>` for `embarkTrack`
- Generate `List<T>` in kotlin instead of `Array<T>`
- Fix documentation for Kotlin-codegen
- Fix failing test
- Commit generated code
