### PR TITLE
Remove excessive logging

### DIFF
--- a/server/bigquery/periodicIngestor.js
+++ b/server/bigquery/periodicIngestor.js
@@ -50,8 +50,6 @@ const ingest = async (config, state) => {
   }
 
   for (const entry of queue) {
-    console.log(`inserting row into BQ ${entry.table}`);
-
     try {
       var filteredRow = await filterFieldsAccordingToEvent(
         entry.eventName,

--- a/server/index.js
+++ b/server/index.js
@@ -49,8 +49,6 @@ app.post("/collect", async (req, res) => {
 
     const timestamp = new Date();
 
-    console.log(`Processing event from ${ip}: ${event}`);
-
     var allProperties = {
       ...event.properties,
     };
@@ -96,8 +94,6 @@ app.post("/collect", async (req, res) => {
       },
     };
     bqAnalytics.track(finalEvent);
-
-    console.log(`Event from ${ip} was processed: ${event}`);
 
     res.status(200).json(finalEvent);
   } catch (err) {


### PR DESCRIPTION
This service currently produces roughly 100M log events per month, or
1/3 of our total volume, which costs us around $200 per month. This PR
removes the worst offenders and will reduce the logs to 1% of
the current volume.